### PR TITLE
Add `$schema` to `cgmanifest.json`

### DIFF
--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -1,44 +1,45 @@
 {
-    "Registrations": [ 
-        {
-            "Component": { 
-                "Type": "git", 
-                "Git": {
-                    "RepositoryUrl": "https://github.com/BayesWatch/deficient-efficient",
-                    "CommitHash": "06d37fa9d3a9e86da982e2368f061a6b9bf5a5e2"
-                }
-            },
-            "DevelopmentDependency": false
-        },
-        {
-            "Component": { 
-                "Type": "git", 
-                "Git": {
-                    "RepositoryUrl": "https://github.com/alecwangcq/EigenDamage-Pytorch",
-                    "CommitHash": "0e2174f80294773e76a8cb73c0bd03f1b7fd2ccf"
-                }
-            },
-            "DevelopmentDependency": false
-        },
-        {
-            "Component": { 
-                "Type": "git", 
-                "Git": {
-                    "RepositoryUrl": "https://github.com/StillKeepTry/Transformer-PyTorch",
-                    "CommitHash": "8d495541a588e18734b2adf1ae6aeda91c7c95f5"
-                }
-            },
-            "DevelopmentDependency": false
-        },
-        {
-            "Component": { 
-                "Type": "git", 
-                "Git": {
-                    "RepositoryUrl": "https://github.com/akamaster/pytorch_resnet_cifar10",
-                    "CommitHash": "820f98cf5a332dacf31e4b41f1db981f5178f660"
-                }
-            },
-            "DevelopmentDependency": false
-        },
-    ]
+  "$schema": "https://json.schemastore.org/component-detection-manifest.json",
+  "Registrations": [
+    {
+      "Component": {
+        "Type": "git",
+        "Git": {
+          "RepositoryUrl": "https://github.com/BayesWatch/deficient-efficient",
+          "CommitHash": "06d37fa9d3a9e86da982e2368f061a6b9bf5a5e2"
+        }
+      },
+      "DevelopmentDependency": false
+    },
+    {
+      "Component": {
+        "Type": "git",
+        "Git": {
+          "RepositoryUrl": "https://github.com/alecwangcq/EigenDamage-Pytorch",
+          "CommitHash": "0e2174f80294773e76a8cb73c0bd03f1b7fd2ccf"
+        }
+      },
+      "DevelopmentDependency": false
+    },
+    {
+      "Component": {
+        "Type": "git",
+        "Git": {
+          "RepositoryUrl": "https://github.com/StillKeepTry/Transformer-PyTorch",
+          "CommitHash": "8d495541a588e18734b2adf1ae6aeda91c7c95f5"
+        }
+      },
+      "DevelopmentDependency": false
+    },
+    {
+      "Component": {
+        "Type": "git",
+        "Git": {
+          "RepositoryUrl": "https://github.com/akamaster/pytorch_resnet_cifar10",
+          "CommitHash": "820f98cf5a332dacf31e4b41f1db981f5178f660"
+        }
+      },
+      "DevelopmentDependency": false
+    }
+  ]
 }


### PR DESCRIPTION
This pull request adds the JSON schema for `cgmanifest.json`.

## FAQ

### Why?

A JSON schema helps you to ensure that your `cgmanifest.json` file is valid.
JSON schema validation is a build-in feature in most modern IDEs like Visual Studio and Visual Studio Code.
Most modern IDEs also provide code-completion for JSON schemas.

### How can I validate my `cgmanifest.json` file?

Most modern IDEs like Visual Studio and Visual Studio Code have a built-in feature to validate JSON files.
You can also use [this small script](https://github.com/JamieMagee/verify-cgmanifest) to validate your `cgmanifest.json` file.

### Why does it suggest camel case for the properties?

Component Detection is able to read camel case and pascal case properties.
However, the JSON schema doesn't have a case-insensitive mode.
We therefore suggest camel case as it's the most common format for JSON.

### Why is the diff so large?

To deserialize the `cgmanifest.json` file, we use [`JSON.parse()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/parse).
However, to serialize the JSON again we use [`prettier`](https://prettier.io/).
We found that, in general, it gave smaller diffs than the default [`JSON.stringify()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify) function.